### PR TITLE
Remove application tag from AndroidManifest

### DIFF
--- a/spanny/src/main/AndroidManifest.xml
+++ b/spanny/src/main/AndroidManifest.xml
@@ -2,8 +2,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.binaryfork.spanny" >
 
-    <application
-        android:allowBackup="true" >
-    </application>
-
 </manifest>


### PR DESCRIPTION
Application tag in the Library is not required.
If the application does not want to allow the backup, this definition can be a problem.

https://github.com/bitstadium/HockeySDK-Android/issues/141
https://github.com/spotify/android-sdk/issues/153
https://github.com/palaima/DebugDrawer/issues/52

Thanks for the nice library!